### PR TITLE
removed login + password from init_db.sql

### DIFF
--- a/src/main/resources/init_db.sql
+++ b/src/main/resources/init_db.sql
@@ -10,8 +10,6 @@ DROP TABLE IF EXISTS `drivers`;
 CREATE TABLE `drivers`  (
                             `id` bigint(0) UNSIGNED NOT NULL AUTO_INCREMENT,
                             `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
-                            `login` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
-                            `password` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
                             `license_number` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
                             `is_deleted` bit(1) NOT NULL DEFAULT b'0',
                             PRIMARY KEY (`id`) USING BTREE


### PR DESCRIPTION
FUCK_UP fix 
 - "В файле init_db.sql прописан скрипт на создание таблички `drivers` в которой уже есть поля `login` и `password` которые студенты только должны добавить в этой домашке"